### PR TITLE
Update meta.yaml to match poetry importlib-metadata pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - vcs.patch
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - intreehooks
   run:
     - python
-    - importlib-metadata >=1.7.0,<2.0.0  # [py<38]
+    - importlib-metadata >=1.7.0  # [py<38]
 
 test:
   imports:


### PR DESCRIPTION
Poetry was updated to remove pin on importlib-metadata = { version = ">=1.6.0", python = "<3.8" }
https://github.com/python-poetry/poetry/commit/c5ac467f708f5be06b20078b0ed5b5fc427c6ff5

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
